### PR TITLE
Make script loader Web Worker friendly

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -3,8 +3,20 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
-	if (window.execScript)
-		window.execScript(src);
-	else
-		eval.call(null, src);
+
+	// Assume that we use a normal browsing mode
+	if(typeof window !== "undefined") {
+		if (window.execScript)
+			window.execScript(src);
+		else
+			eval.call(null, src);
+	}
+	
+	// Assume that we load a script in a web worker
+	if(typeof self !== "undefined") {
+		if (self.execScript)
+			self.execScript(src);
+		else
+			eval.call(null, src);
+	}
 }


### PR DESCRIPTION
Since `window` is not accessible in a Web Worker context, code like:
`require("script!myModule.js”);` will not work.

This is a fix.

A (maybe) better solution would be to have `webworker-script-loader` 
but I don't have an opinion on that.
