### PR TITLE
feat(index): add sourcemap support (`options.sourceMap`)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,85 @@
-# script loader for webpack
+[![npm][npm]][npm-url]
+[![node][node]][node-url]
+[![deps][deps]][deps-url]
+[![tests][tests]][tests-url]
+[![coverage][cover]][cover-url]
+[![chat][chat]][chat-url]
 
-## Usage
+<div align="center">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200"
+      src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+  <h1>Script Loader</h1>
+</div>
 
-``` javascript
-require("script-loader!./file.js");
-// => execute file.js once in global context
+<h2 align="center">Install</h2>
+
+```bash
+npm install --save-dev script-loader
 ```
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+<h2 align="center">Usage</h2>
 
-Does nothing in node.js.
+Executes JS script once in global context.
 
-## License
+> :warning: Doesn't work in NodeJS
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+### Config (recommended)
+
+```js
+import exec from 'script.exec.js';
+```
+
+**webpack.config.js**
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.exec.js$/,
+        use: [ 'script-loader' ]
+      }
+    ]
+  }
+}
+```
+
+### Inline
+
+```js
+import exec from 'script-loader!./script.js';
+```
+
+<h2 align="center">Maintainer</h2>
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150 height="150" src="https://github.com/sokra.png?s=150">
+        <br>
+        <a href="https://github.com/sokra">Tobias Koppers</a>
+      </td>
+    <tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/script-loader.svg
+[npm-url]: https://npmjs.com/package/script-loader
+
+[node]: https://img.shields.io/node/v/script-loader.svg
+[node-url]: https://nodejs.org
+
+[deps]: https://david-dm.org/webpack/script-loader.svg
+[deps-url]: https://david-dm.org/webpack/script-loader
+
+[tests]: http://img.shields.io/travis/webpack/script-loader.svg
+[tests-url]: https://travis-ci.org/webpack/script-loader
+
+[cover]: https://coveralls.io/repos/github/webpack/script-loader/badge.svg
+[cover-url]: https://coveralls.io/github/webpack/script-loader
+
+[chat]: https://badges.gitter.im/webpack/webpack.svg
+[chat-url]: https://gitter.im/webpack/webpack

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Executes JS script once in global context.
 
 > :warning: Doesn't work in NodeJS
 
+<h2 align="center">Options</h2>
+
+|Name|Type|Default|Description|
+|:-----:|:----:|:------:|:-----------|
+|**`sourceMap`**|`{Boolean}`|`false`| Enable/Disable Sourcemaps|
+
 ### Config (recommended)
 
 ```js

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ require("script!./file.js");
 // => execute file.js once in global context
 ```
 
+[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+
 Does nothing in node.js.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![npm][npm]][npm-url]
 [![node][node]][node-url]
 [![deps][deps]][deps-url]
-[![tests][tests]][tests-url]
-[![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
 
 <div align="center">
@@ -93,12 +91,6 @@ import exec from 'script-loader!./script.js';
 
 [deps]: https://david-dm.org/webpack/script-loader.svg
 [deps-url]: https://david-dm.org/webpack/script-loader
-
-[tests]: http://img.shields.io/travis/webpack/script-loader.svg
-[tests-url]: https://travis-ci.org/webpack/script-loader
-
-[cover]: https://coveralls.io/repos/github/webpack/script-loader/badge.svg
-[cover-url]: https://coveralls.io/github/webpack/script-loader
 
 [chat]: https://badges.gitter.im/webpack/webpack.svg
 [chat-url]: https://gitter.im/webpack/webpack

--- a/README.md
+++ b/README.md
@@ -51,17 +51,36 @@ module.exports = {
 import exec from 'script-loader!./script.js';
 ```
 
-<h2 align="center">Maintainer</h2>
+<h2 align="center">Maintainers</h2>
 
 <table>
   <tbody>
     <tr>
       <td align="center">
-        <img width="150 height="150" src="https://github.com/sokra.png?s=150">
-        <br>
-        <a href="https://github.com/sokra">Tobias Koppers</a>
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/166921?v=3&s=150">
+        </br>
+        <a href="https://github.com/bebraw">Juho Vepsäläinen</a>
       </td>
-    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/8420490?v=3&s=150">
+        </br>
+        <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/533616?v=3&s=150">
+        </br>
+        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/3408176?v=3&s=150">
+        </br>
+        <a href="https://github.com/TheLarkInn">Sean Larkin</a>
+      </td>
+    </tr>
   <tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ``` javascript
-require("script!./file.js");
+require("script-loader!./file.js");
 // => execute file.js once in global context
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.exec.js$/,
+        test: /\.exec\.js$/,
         use: [ 'script-loader' ]
       }
     ]

--- a/addScript.js
+++ b/addScript.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
-	if (typeof execScript === "function")
+	if (typeof execScript !== "undefined")
 		execScript(src);
 	else
 		eval.call(null, src);

--- a/addScript.js
+++ b/addScript.js
@@ -3,8 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
-	if (window.execScript)
-		window.execScript(src);
+	if (typeof execScript === "function")
+		execScript(src);
 	else
 		eval.call(null, src);
 }

--- a/index.js
+++ b/index.js
@@ -2,14 +2,18 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var loaderUtils = require("loader-utils");
 var path = require("path");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
+	var loader = this;
+	var options = loaderUtils.getOptions(loader) || {};
+
 	this.cacheable && this.cacheable();
 	return "require(" + JSON.stringify("!!" + path.join(__dirname, "addScript.js")) + ")"+
 			"(require(" +
 			JSON.stringify("!!" + require.resolve("raw-loader") + "!" + remainingRequest) + ")" +
-				(this.debug ?
+				(this.debug || options.sourceMap ?
 					"+" +
 						JSON.stringify(
 							"\n\n// SCRIPT-LOADER FOOTER\n//# sourceURL=script:///" +

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var path = require("path");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
-	return "require(" + JSON.stringify("!" + path.join(__dirname, "addScript.js")) + ")"+
+	return "require(" + JSON.stringify("!!" + path.join(__dirname, "addScript.js")) + ")"+
 			"(require(" +
-			JSON.stringify("!" + require.resolve("raw-loader") + "!" + remainingRequest) + ")" +
+			JSON.stringify("!!" + require.resolve("raw-loader") + "!" + remainingRequest) + ")" +
 				(this.debug ?
 					"+" +
 						JSON.stringify(

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports.pitch = function(remainingRequest) {
 				(this.debug ?
 					"+" +
 						JSON.stringify(
-							"\n\n// SCRIPT-LOADER FOOTER\n//@ sourceURL=script:///" +
+							"\n\n// SCRIPT-LOADER FOOTER\n//# sourceURL=script:///" +
 								encodeURI(remainingRequest.replace(/^!/, "")).replace(/%5C|%2F/g, "/").replace(/\?/, "%3F").replace(/^\//, "")
 						) :
 					"") +

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-	"name": "script-loader",
-	"version": "0.6.1",
-	"author": "Tobias Koppers @sokra",
-	"description": "script loader module for webpack",
-	"dependencies": {
-		"raw-loader": "~0.5.1"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:webpack/script-loader.git"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+  "name": "script-loader",
+  "version": "0.7.0",
+  "author": "Tobias Koppers @sokra",
+  "description": "script loader module for webpack",
+  "dependencies": {
+    "raw-loader": "~0.5.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:webpack/script-loader.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "script-loader",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"author": "Tobias Koppers @sokra",
 	"description": "script loader module for webpack",
 	"dependencies": {
-		"raw-loader": "0.5.x"
+		"raw-loader": "~0.5.1"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "script-loader",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"author": "Tobias Koppers @sokra",
 	"description": "script loader module for webpack",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "script loader module for webpack",
   "dependencies": {
+    "loader-utils": "~1.1.0",
     "raw-loader": "~0.5.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "script-loader",
-	"version": "0.5.2",
+	"version": "0.6.0",
 	"author": "Tobias Koppers @sokra",
 	"description": "script loader module for webpack",
 	"dependencies": {


### PR DESCRIPTION
### PR (Notable Changes)

```
chore: update `loader-utils` v0.0.0...1.1.0 (:label: Major)
feat: support sourcemap support (`options.sourceMap`)
```

Global options like debug are deprecated[0] in `webpack >= 2.0.0`, and require
`LoaderOptionsPlugin` to be enabled.  This commit adds support for a loader
`options.sourceMap`, to enable configuring this on a loader/require level.

[0] https://webpack.js.org/plugins/loader-options-plugin/

## Issues

Closes #30

> Edited by @michael-ciniawsky (Formatting && Grammar)