### PR TITLE
use a script tag instead of eval

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -2,8 +2,19 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var firstScript;
+
+function inlineScript(src) {
+	var script = document.createElement('script');
+	script.innerHTML = src;
+	firstScript = firstScript || document.getElementsByTagName('script')[0];
+	firstScript.parentNode.insertBefore(script, firstScript);
+}
+
 module.exports = function(src) {
-	if (typeof execScript !== "undefined")
+	if (typeof document !== 'undefined')
+		inlineScript(src);
+	else if (typeof execScript !== "undefined")
 		execScript(src);
 	else
 		eval.call(null, src);


### PR DESCRIPTION
Global window error events do not work with eval in chrome. (You get a useless `Script Error` message)

This embeds the script in a tag and sticks it in the DOM instead of using eval (when the document is available).

https://jsfiddle.net/bewpgj9m/1/