### PR TITLE
fix: modify `script` evaluation for IE11

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -3,8 +3,15 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
-	if (typeof execScript !== "undefined")
-		execScript(src);
-	else
-		eval.call(null, src);
+	try {
+		if (typeof eval !== "undefined") {
+			eval.call(null, src);
+		} else if (typeof execScript !== "undefined") {
+			execScript(src);
+		} else {
+			console.error("[Script Loader] EvalError: No eval function available");
+		}
+	} catch (error) {
+		console.error("[Script Loader] ", error.message);
+	}
 }


### PR DESCRIPTION
### Pull Request (Notable Changes)

I've moved up the check for `eval` because IE11 still has the `execScript` function, but throws an error when it's called.

The added error handling allows us to gracefuly reject scripts with non compatible code (like ES6 syntax). It would be better if we could transpile with babel before evaluating, but I don't know how we could implement that. There's already a separate issue regarding this feature (See #40).

### Issues

Fixes #36 
Fixes #39 

> Edited by @michael-ciniawsky (Formatting && Fixes #Issue Support)