### PR TITLE
fix: IE =< 8 incompatibility regression

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -3,15 +3,25 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
+	function log(error) {
+		(typeof console !== "undefined")
+		&& (console.error || console.log)("[Script Loader]", error);
+	}
+
+	// Check for IE =< 8
+	function isIE() {
+		return typeof attachEvent !== "undefined" && typeof addEventListener === "undefined";
+	}
+
 	try {
-		if (typeof eval !== "undefined") {
-			eval.call(null, src);
-		} else if (typeof execScript !== "undefined") {
+		if (typeof execScript !== "undefined" && isIE()) {
 			execScript(src);
+		} else if (typeof eval !== "undefined") {
+			eval.call(null, src);
 		} else {
-			console.error("[Script Loader] EvalError: No eval function available");
+			log("EvalError: No eval function available");
 		}
 	} catch (error) {
-		console.error("[Script Loader] ", error.message);
+		log(error);
 	}
 }


### PR DESCRIPTION
0.7.1 breaks IE8, this commit takes it back

### Notabel Changes

1. IE8 does not have console.error
2. eval.call(null, src) does not work for IE8, the eval code is limited to local scope, not global

### Issues 

Related #41 