### PR TITLE
feat(addScript): disable `'use strict'` to allow setting globals

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -17,6 +17,7 @@ module.exports = function(src) {
 		if (typeof execScript !== "undefined" && isIE()) {
 			execScript(src);
 		} else if (typeof eval !== "undefined") {
+			src = src.replace(/('|")use strict('|");?/, '');
 			eval.call(null, src);
 		} else {
 			log("EvalError: No eval function available");


### PR DESCRIPTION
I wasn't able to get some external scripts loaded into the global context since they're in strict mode.  See http://whereswalden.com/2011/01/10/new-es5-strict-mode-support-new-vars-created-by-strict-mode-eval-code-are-local-to-that-code-only/