### PR TITLE
feat(index): add sourcemap support (`options.sourceMap`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports.pitch = function(remainingRequest) {
 	return "require(" + JSON.stringify("!!" + path.join(__dirname, "addScript.js")) + ")"+
 			"(require(" +
 			JSON.stringify("!!" + require.resolve("raw-loader") + "!" + remainingRequest) + ")" +
-				(this.debug ?
+				(this.debug || (this.query && this.query.sourceMap) ?
 					"+" +
 						JSON.stringify(
 							"\n\n// SCRIPT-LOADER FOOTER\n//# sourceURL=script:///" +


### PR DESCRIPTION
Currently, we only get the source map if web pack is in debug mode. This adds the sourceMap parameter that will also add it.

### Type

- [x] Feature

### Issues

- Fixes #30 

### SemVer

- [x] Minor