### PR TITLE
don't suggest 'import exec from ...'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Executes JS script once in global context.
 ### Config (recommended)
 
 ```js
-import exec from 'script.exec.js';
+import './script.exec.js';
 ```
 
 **webpack.config.js**
@@ -46,7 +46,7 @@ module.exports = {
 ### Inline
 
 ```js
-import exec from 'script-loader!./script.js';
+import 'script-loader!./script.js';
 ```
 
 <h2 align="center">Maintainers</h2>


### PR DESCRIPTION
a) it's unclear what `exec` means here,
b) at least for me, that syntax generates a confusing error:

```
TS2306: File '/Users/nornagon/.../my-app/.../script.js' is not a module.
```