### PR TITLE
Fix broken fragment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import 'script-loader!./script.js';
 |                    Name                     |         Type          |     Default     | Description                                 |
 | :-----------------------------------------: | :-------------------: | :-------------: | :------------------------------------------ |
 |        **[`sourceMap`](#sourcemap)**        |      `{Boolean}`      |     `false`     | Enable/Disable Sourcemaps
-|        **[`useStrict`](#useStrict)**        |      `{Boolean}`      |     `true`      | Enable/Disable useStrict
+|        **[`useStrict`](#usestrict)**        |      `{Boolean}`      |     `true`      | Enable/Disable useStrict
 
 
 ### `sourceMap`


### PR DESCRIPTION
The `#useStrict` fragment link has no target because the markdown gets translated to `#usestrict` (all lower-case

In Github README's using mixed-case fragment url's works because Github has a script that intercepts the navigation and jumps to the fragment.

But the fragment navigation is broken in webpack.js.org, where this README is also used